### PR TITLE
Fix optional argument order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
 	"name": "arc-eslint",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "arc-eslint",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"description": "ESlint for arcanist/phabricator (extension)",
 	"repository": "https://github.com/VISIT-X/arc-eslint",
 	"license": "AGPL-3.0-or-later",

--- a/src/ESLintLinter.php
+++ b/src/ESLintLinter.php
@@ -94,7 +94,7 @@ final class ESLintLinter extends ArcanistExternalLinter {
 		return false;
 	}
 
-	protected function parseLinterOutput($path, $err, $stdout = "{}", $stderr) {
+	protected function parseLinterOutput($path, $err, $stderr, $stdout = "{}") {
 
 		$json     = json_decode($stdout, true);
 		$messages = [];


### PR DESCRIPTION
Without this, there is an error. This might be sensible to the PHP version
`Optional parameter $stdout declared before required parameter $stderr is implicitly treated as a required parameter at [<arcanist>/src/init/lib/PhutilBootloader.php:275]`

Please update the package asap if you approve this PR :pray: 